### PR TITLE
fix dynamic resolv.conf

### DIFF
--- a/overlay/build/helpers.sh
+++ b/overlay/build/helpers.sh
@@ -160,6 +160,9 @@ setup_tor_enforcement_dns()
     display_alert "Point /etc/resolvconf/resolv.conf.d/head to the local Tor DNS resolver" "/etc/resolvconf/resolv.conf.d/head"  ""
     local resconfhead=/etc/resolvconf/resolv.conf.d/head
     echo "nameserver 127.0.0.1" > $resconfhead
+    rm /etc/resolv.conf 2>/dev/null
+    ln -s /etc/resolvconf/run/resolv.conf
+    resolvconf -u
 
     # enable DNS, transparent proxy and misc setting
     display_alert "Enable Tor DNS, transparent proxy and misc settings" "/etc/tor/torrc" ""


### PR DESCRIPTION
If dynamic resolv.conf approach is used, `/etc/resolv.conf` must not exist as a static file, but be a symbolic link to `/etc/resolvconf/run/resolv.conf` instead.
And after any changes in the files under `/etc/resolvconf/resolv.conf.d/` the command `resolvconf -u` needs to be called to re-generate the dynamic file.