### PR TITLE
fix missing symbolic link to generated resolv.conf

### DIFF
--- a/overlay/build/helpers.sh
+++ b/overlay/build/helpers.sh
@@ -160,6 +160,11 @@ setup_tor_enforcement_dns()
     display_alert "Point /etc/resolvconf/resolv.conf.d/head to the local Tor DNS resolver" "/etc/resolvconf/resolv.conf.d/head"  ""
     local resconfhead=/etc/resolvconf/resolv.conf.d/head
     echo "nameserver 127.0.0.1" > $resconfhead
+    
+    # remove static resolv.conf and setup symbolic link to generated resolv.conf
+    rm /etc/resolv.conf 2>/dev/null
+    ln -s /etc/resolvconf/run/resolv.conf /etc/resolv.conf
+    resolvconf -u
 
     # enable DNS, transparent proxy and misc setting
     display_alert "Enable Tor DNS, transparent proxy and misc settings" "/etc/tor/torrc" ""


### PR DESCRIPTION
While the `local TOR DNS resolver` was added to `/etc/resolvconf/resolv.conf.d/head`, this only becomes **effective**, if the resolv.conf file is re-generated via the `resolvconf -u` command and `/etc/resolv.conf` is a symbolic link to `/etc/resolvconf/run/resolv.conf`.